### PR TITLE
Suggested v2.0 Release

### DIFF
--- a/src/Xtensible.TusDotNet.Azure/AzureBlobExpirationDetailsStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobExpirationDetailsStore.cs
@@ -6,10 +6,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
-using Xtensible.Time;
 
 namespace Xtensible.TusDotNet.Azure
 {
+    
+    // https://ayende.com/blog/3408/dealing-with-time-in-tests
+    public static class SystemTime
+    {
+        public static Func<DateTimeOffset> UtcNow = () => DateTimeOffset.UtcNow;
+    }
+    
     public class AzureBlobExpirationDetailsStore : ITusExpirationDetailsStore
     {
         private const string ExpirationKey = "ExpiresAt";
@@ -47,7 +53,7 @@ namespace Xtensible.TusDotNet.Azure
         public async Task<IEnumerable<string>> GetExpiredFilesAsync(CancellationToken cancellationToken)
         {
             var blobServiceClient = new BlobServiceClient(_connectionString);
-            var blobItems = blobServiceClient.FindBlobsByTagsAsync($"@container='{_containerName}' AND {ExpirationKey} < '{Clock.Default.UtcNow:s}'", cancellationToken);
+            var blobItems = blobServiceClient.FindBlobsByTagsAsync($"@container='{_containerName}' AND {ExpirationKey} < '{SystemTime.UtcNow():s}'", cancellationToken);
             var toDelete = new List<string>();
             var enumerator = blobItems.GetAsyncEnumerator(cancellationToken);
             while (await enumerator.MoveNextAsync())

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
@@ -48,14 +48,14 @@ namespace Xtensible.TusDotNet.Azure
         public AzureBlobTusStore(string connectionString, string containerName, AzureBlobTusStoreOptions options = default)
         {
             options ??= new AzureBlobTusStoreOptions();
-            _expirationDetailsStore = options.ExpirationDetailsStore ?? new AzureBlobExpirationDetailsStore(connectionString, containerName);
+            _blobPath = options.BlobPath;
+            _expirationDetailsStore = options.ExpirationDetailsStore ?? new AzureBlobExpirationDetailsStore(connectionString, containerName, _blobPath);
             _connectionString = connectionString;
             _containerName = containerName;
             _metadataParsingStrategy = options.MetadataParsingStrategy;
             _maxDegreeOfDeleteParallelism = options.MaxDegreeOfDeleteParallelism;
             _isContainerPublic = options.IsContainerPublic;
             _fileIdGeneratorAsync = options.FileIdGeneratorAsync ?? (metadata => Task.FromResult(Guid.NewGuid().ToString("N")));
-            _blobPath = options.BlobPath;
         }
 
         public async Task<string> CreateFileAsync(long uploadLength, string metadata, CancellationToken cancellationToken)

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
@@ -13,7 +13,7 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using tusdotnet.Interfaces;
 using tusdotnet.Models;
-using Xtensible.Time;
+
 namespace Xtensible.TusDotNet.Azure
 {
     public class AzureBlobTusStore : ITusStore,

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
@@ -37,6 +37,7 @@ namespace Xtensible.TusDotNet.Azure
         private static readonly IEnumerable<string> SupportedChecksumAlgorithms = new ReadOnlyCollection<string>(new[] { "md5" });
         private readonly string _connectionString;
         private readonly string _containerName;
+        private readonly string _blobPath;
         private readonly bool _isContainerPublic;
         private readonly int _maxDegreeOfDeleteParallelism;
         private readonly MetadataParsingStrategy _metadataParsingStrategy;
@@ -54,6 +55,7 @@ namespace Xtensible.TusDotNet.Azure
             _maxDegreeOfDeleteParallelism = options.MaxDegreeOfDeleteParallelism;
             _isContainerPublic = options.IsContainerPublic;
             _fileIdGeneratorAsync = options.FileIdGeneratorAsync ?? (metadata => Task.FromResult(Guid.NewGuid().ToString("N")));
+            _blobPath = options.BlobPath;
         }
 
         public async Task<string> CreateFileAsync(long uploadLength, string metadata, CancellationToken cancellationToken)
@@ -271,7 +273,7 @@ namespace Xtensible.TusDotNet.Azure
 
         private AppendBlobClient GetAppendBlobClient(string fileId)
         {
-            return new AppendBlobClient(_connectionString, _containerName, fileId);
+            return new AppendBlobClient(_connectionString, _containerName, Path.Combine(_blobPath, fileId));
         }
 
         private async Task<string> GetBlobMetadataAsync(string fileId, string key, CancellationToken cancellationToken)

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
@@ -161,8 +162,15 @@ namespace Xtensible.TusDotNet.Azure
                     {
                         using (var ms = new MemoryStream(writeBuffer, 0, bytesWritten))
                         {
-                            md5Hash = ChecksumProvider.GetChecksum("md5", ms);
-                            await appendBlobClient.AppendBlockAsync(ms, md5Hash, cancellationToken: cancellationToken);
+                            var options = new AppendBlobAppendBlockOptions
+                            {
+                                TransferValidation = new UploadTransferValidationOptions
+                                {
+                                    ChecksumAlgorithm = StorageChecksumAlgorithm.MD5,
+                                    PrecalculatedChecksum = ChecksumProvider.GetChecksum("md5", ms)
+                                }
+                            };
+                            await appendBlobClient.AppendBlockAsync(ms, options, cancellationToken: cancellationToken);
                         }
                         bytesWritten = 0;
                     }
@@ -172,8 +180,15 @@ namespace Xtensible.TusDotNet.Azure
                 {
                     using (var ms = new MemoryStream(writeBuffer, 0, bytesWritten))
                     {
-                        md5Hash = ChecksumProvider.GetChecksum("md5", ms);
-                        await appendBlobClient.AppendBlockAsync(ms, md5Hash, cancellationToken: cancellationToken);
+                        var options = new AppendBlobAppendBlockOptions
+                        {
+                            TransferValidation = new UploadTransferValidationOptions
+                            {
+                                ChecksumAlgorithm = StorageChecksumAlgorithm.MD5,
+                                PrecalculatedChecksum = ChecksumProvider.GetChecksum("md5", ms)
+                            }
+                        };
+                        await appendBlobClient.AppendBlockAsync(ms, options, cancellationToken: cancellationToken);
                     }
                 }
 

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
@@ -13,9 +13,6 @@ using Azure.Storage.Blobs.Specialized;
 using tusdotnet.Interfaces;
 using tusdotnet.Models;
 using Xtensible.Time;
-#if pipelines
-using System.IO.Pipelines;
-#endif
 namespace Xtensible.TusDotNet.Azure
 {
     public class AzureBlobTusStore : ITusStore,
@@ -25,9 +22,6 @@ namespace Xtensible.TusDotNet.Azure
         , ITusExpirationStore
 #if ENABLE_CHECKSUM
         , ITusChecksumStore // we can only efficiently verify the checksum if we cap chunk sizes to <AppendBlobBlockSize> (4MB) or less
-#endif
-#if pipelines
- //       , ITusPipelineStore //todo
 #endif
 
     {
@@ -214,12 +208,6 @@ namespace Xtensible.TusDotNet.Azure
             return long.Parse(await GetBlobMetadataAsync(fileId, UploadOffsetKey, cancellationToken));
         }
 
-#if pipelines
-        public Task<long> AppendDataAsync(string fileId, PipeReader pipeReader, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-#endif
         public async Task DeleteFileAsync(string fileId, CancellationToken cancellationToken)
         {
             await EnsureContainerExistsAsync(_connectionString, _containerName, _isContainerPublic, cancellationToken);

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStoreOptions.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStoreOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using tusdotnet.Models;
 
@@ -11,7 +12,7 @@ namespace Xtensible.TusDotNet.Azure
         public int MaxDegreeOfDeleteParallelism { get; set; } = 4;
         public bool IsContainerPublic { get; set; } = false;
         public Func<string, Task<string>> FileIdGeneratorAsync { get; set; } = default;
-
         public string BlobPath { get; set; } = "";
+        public Action<Dictionary<string, string>> UpdateAzureMeta { get; set; } = default;
     }
 }

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStoreOptions.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStoreOptions.cs
@@ -11,5 +11,7 @@ namespace Xtensible.TusDotNet.Azure
         public int MaxDegreeOfDeleteParallelism { get; set; } = 4;
         public bool IsContainerPublic { get; set; } = false;
         public Func<string, Task<string>> FileIdGeneratorAsync { get; set; } = default;
+
+        public string BlobPath { get; set; } = "";
     }
 }

--- a/src/Xtensible.TusDotNet.Azure/NullExpirationDetailsStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/NullExpirationDetailsStore.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Xtensible.Time;
 
 namespace Xtensible.TusDotNet.Azure
 {

--- a/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
+++ b/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,13 +20,7 @@
     <PackageReference Include="tusdotnet" Version="2.6.0" />
     <PackageReference Include="Xtensible.Time.Clock" Version="1.1.0" />
   </ItemGroup>
-
-
-  <!-- Package references for .NET Core 3.1+ -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
+	
   <!-- SourceLink -->
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
+++ b/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
@@ -27,10 +27,6 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);pipelines</DefineConstants>
-  </PropertyGroup>
-
   <!-- SourceLink -->
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
+++ b/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.12.0" />
-    <PackageReference Include="tusdotnet" Version="2.6.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
+    <PackageReference Include="tusdotnet" Version="2.7.2" />
     <PackageReference Include="Xtensible.Time.Clock" Version="1.1.0" />
   </ItemGroup>
 	

--- a/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
+++ b/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
@@ -35,16 +35,16 @@
     <RepositoryUrl>https://github.com/giometrix/Xtensible.TusDotNet.Azure</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>tus;tusdotnet;azure;blob;azure-blob-storage;upload</PackageTags>
-    <PackageReleaseNotes>Expose file Uri</PackageReleaseNotes>
+    <PackageReleaseNotes>Allow for custom file paths</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageIcon>xtensible-x.png</PackageIcon>
     <AssemblyVersion>1.4.0.0</AssemblyVersion>
     <FileVersion>1.4.0.0</FileVersion>
-    <Version>1.4.0</Version>
+    <Version>2.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
+++ b/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
+++ b/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="tusdotnet" Version="2.7.2" />
-    <PackageReference Include="Xtensible.Time.Clock" Version="1.1.0" />
   </ItemGroup>
 	
   <!-- SourceLink -->

--- a/test/Xtensible.TusDotNet.Azure.Benchmarks/Xtensible.TusDotNet.Azure.Benchmarks.csproj
+++ b/test/Xtensible.TusDotNet.Azure.Benchmarks/Xtensible.TusDotNet.Azure.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/Xtensible.TusDotNet.Azure.Tests/BlobStorageTests.cs
+++ b/test/Xtensible.TusDotNet.Azure.Tests/BlobStorageTests.cs
@@ -132,6 +132,10 @@ namespace Xtensible.TusDotNet.Azure.Tests
         [Fact]
         public async Task expire_file()
         {
+            if (_connectionString.Contains("UseDev"))
+            {
+                return;
+            }
             var fileInfo = new FileInfo(SmallFileName);
             var id = await _azureBlobTusStore.CreateFileAsync(fileInfo.Length, GetMetadata(("filename", SmallFileName), ("test-id", nameof(append_file))), CancellationToken.None);
             await _azureBlobTusStore.SetExpirationAsync(id, Clock.Default.UtcNow.Subtract(TimeSpan.FromHours(1)), CancellationToken.None);

--- a/test/Xtensible.TusDotNet.Azure.Tests/BlobStorageTests.cs
+++ b/test/Xtensible.TusDotNet.Azure.Tests/BlobStorageTests.cs
@@ -160,7 +160,7 @@ namespace Xtensible.TusDotNet.Azure.Tests
         [Fact]
         public async Task expire_file()
         {
-            if (_connectionString.Contains("UseDev"))
+            if (_connectionString.Contains("UseDev") || _connectionString.Contains("devstoreaccount"))
             {
                 return;
             }

--- a/test/Xtensible.TusDotNet.Azure.Tests/Xtensible.TusDotNet.Azure.Tests.csproj
+++ b/test/Xtensible.TusDotNet.Azure.Tests/Xtensible.TusDotNet.Azure.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/test/Xtensible.TusDotNet.Azure.Tests/Xtensible.TusDotNet.Azure.Tests.csproj
+++ b/test/Xtensible.TusDotNet.Azure.Tests/Xtensible.TusDotNet.Azure.Tests.csproj
@@ -8,16 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Removed older .net versions, now supports .net6.0 and .net8.0
- Updated packages to latest version
- Updated Azure upload checksum code
- Simplified clock for unit testing
- Expires test now skipped if using Azurite
- Added two new options
  - BlobPath - allows specifying a path for the blob to be stored
  - UpdateAzureMeta - an Action that allows updating the metadata dictionary before it is used to create the blob 

Suggested a 2.0 release as it would be a breaking change to remove older .net versions.  