### PR TITLE
Adding support for Azure Managed Identity

### DIFF
--- a/src/Xtensible.TusDotNet.Azure/AzureBlobClientFactory.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobClientFactory.cs
@@ -1,0 +1,68 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Xtensible.TusDotNet.Azure
+{
+    internal static class AzureBlobClientFactory
+    {
+        public static BlobServiceClient CreateBlobServiceClient(AzureBlobTusStoreAuthenticationMode authenticationMode, string connectionString)
+        {
+
+            if (authenticationMode == AzureBlobTusStoreAuthenticationMode.SystemAssignedManagedIdentity)
+            {
+                var connectionStringIsUri = Uri.TryCreate(connectionString, UriKind.Absolute, out var blobStorageUri);
+                if (!connectionStringIsUri)
+                {
+                    throw new ArgumentException("connectionString must be a Azure Blob Storage URI when authentication mode is SystemAssignedManagedIdentity");
+                }
+
+                return new BlobServiceClient(blobStorageUri, new DefaultAzureCredential());
+            }
+            else
+            {
+                return new BlobServiceClient(connectionString);
+            }
+        }
+
+        public static AppendBlobClient CreateAppendBlobClient(AzureBlobTusStoreAuthenticationMode authenticationMode, string connectionString, string containerName, string blobPath) 
+        {
+            if (authenticationMode == AzureBlobTusStoreAuthenticationMode.SystemAssignedManagedIdentity)
+            {
+                var connectionStringIsUri = Uri.TryCreate(connectionString, UriKind.Absolute, out var blobStorageUri);
+                if (!connectionStringIsUri)
+                {
+                    throw new ArgumentException("connectionString must be a Azure Blob Storage URI when authentication mode is SystemAssignedManagedIdentity");
+                }
+                return new AppendBlobClient(new Uri(blobStorageUri, $"{containerName}/{blobPath}"), new DefaultAzureCredential());
+            }
+            else
+            {
+                return new AppendBlobClient(connectionString, containerName, blobPath);
+            }
+        }
+
+        public static BlobContainerClient CreateBlobContainerClient(AzureBlobTusStoreAuthenticationMode authenticationMode, string connectionString, string containerName) 
+        {
+            if (authenticationMode == AzureBlobTusStoreAuthenticationMode.SystemAssignedManagedIdentity)
+            {
+                var connectionStringIsUri = Uri.TryCreate(connectionString, UriKind.Absolute, out var blobStorageUri);
+                if (!connectionStringIsUri)
+                {
+                    throw new ArgumentException("connectionString must be a Azure Blob Storage URI when authentication mode is SystemAssignedManagedIdentity");
+                }
+                return new BlobContainerClient(new Uri(blobStorageUri, containerName), new DefaultAzureCredential());
+            }
+            else
+            {
+                return new BlobContainerClient(connectionString, containerName);
+            }
+        }
+    }
+}

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStoreAuthenticationMode.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStoreAuthenticationMode.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xtensible.TusDotNet.Azure
+{
+    /// <summary>
+    /// Modes for how the library authenticates with the Azure storage account.
+    /// ConnectionString: Use a connection string with either a Shared Access Signature (SAS) or access key. See https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string.
+    /// SystemAssignedManagedIdentity: Authenticate using Azure system-assigned managed identity. See https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview.
+    /// </summary>
+    public enum AzureBlobTusStoreAuthenticationMode
+    {
+        ConnectionString = 0,
+        SystemAssignedManagedIdentity = 1
+    }
+}

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStoreOptions.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStoreOptions.cs
@@ -14,5 +14,6 @@ namespace Xtensible.TusDotNet.Azure
         public Func<string, Task<string>> FileIdGeneratorAsync { get; set; } = default;
         public string BlobPath { get; set; } = "";
         public Action<Dictionary<string, string>> UpdateAzureMeta { get; set; } = default;
+        public AzureBlobTusStoreAuthenticationMode AuthenticationMode { get; set; } = AzureBlobTusStoreAuthenticationMode.ConnectionString;
     }
 }

--- a/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
+++ b/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.11.2" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="tusdotnet" Version="2.7.2" />
   </ItemGroup>
@@ -41,7 +42,7 @@
     <PackageIcon>xtensible-x.png</PackageIcon>
     <AssemblyVersion>1.4.0.0</AssemblyVersion>
     <FileVersion>1.4.0.0</FileVersion>
-    <Version>2.0</Version>
+    <Version>2.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">


### PR DESCRIPTION
Using managed identities allows Azure resources to use Azure AD for authenticating and RBAC for authorizing requests to the blob storage account, instead of using a connection string. See https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview

Changes introduced in this PR:
- Extract blob client creation into AzureBlobClientFactory - because there's some more logic needed now to check how the blob client should be created (using a connection string vs AzureDefaultCredentials)
- Add an AuthenticationMode property in the AzureBlobTusStoreOptions to specify how we should authenticate with the storage account. It's set to ConnectionString as default, to preserve backwards compatibility.
- The connectionString argument in AzureBlobTusStore should be set to just the URI of the blob storage account in the case of managed identity authentication.
- Bump to version 2.1 because of the introduction of new functionality.

We implemented this in our fork, and wanted to contribute it back in hopes it can be of use for the project. If you feel any improvements are needed, please let me know and I'll be happy to oblige.