### PR TITLE
The System.Security.Cryptography.MD5 class is not thread safe, so it must be created on use.

### DIFF
--- a/src/Xtensible.TusDotNet.Azure/ChecksumProvider.cs
+++ b/src/Xtensible.TusDotNet.Azure/ChecksumProvider.cs
@@ -8,15 +8,16 @@ namespace Xtensible.TusDotNet.Azure
 {
     internal static class ChecksumProvider
     {
-        internal static readonly IEnumerable<string> SupportedChecksumAlgorithms = new ReadOnlyCollection<string>(new[] { "md5" });
-        private static readonly MD5 MD5CryptoServiceProvider = MD5.Create();
         internal static byte[] GetChecksum(string algorithm, MemoryStream contents)
         {
             byte[] checksum;
             switch (algorithm)
             {
                 case "md5":
-                    checksum = MD5CryptoServiceProvider.ComputeHash(contents);
+                    using (var md5 = MD5.Create())
+                    {
+                        checksum = md5.ComputeHash(contents);
+                    }
                     break;
                 default:
                     throw new NotSupportedException();

--- a/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
+++ b/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
@@ -42,7 +42,7 @@
     <PackageIcon>xtensible-x.png</PackageIcon>
     <AssemblyVersion>1.4.0.0</AssemblyVersion>
     <FileVersion>1.4.0.0</FileVersion>
-    <Version>2.1</Version>
+    <Version>2.1.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">


### PR DESCRIPTION
This fixes random crashes in multi-threaded applications (e.g. webapps) that uses this library with Tus where more than one upload is happening at the same time. Creating the instance has a slight overhead, but it is measured in microseconds or less.
