### PR TITLE
Allow for multiple containers

### DIFF
--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
@@ -2,13 +2,11 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage;
-using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using tusdotnet.Interfaces;
@@ -24,6 +22,7 @@ namespace Xtensible.TusDotNet.Azure
 #if ENABLE_CHECKSUM
         , ITusChecksumStore // we can only efficiently verify the checksum if we cap chunk sizes to <AppendBlobBlockSize> (4MB) or less
 #endif
+        ,IDisposable
 
     {
         private const int AppendBlobBlockSize = 4_194_304; //4MB
@@ -308,6 +307,11 @@ namespace Xtensible.TusDotNet.Azure
             var blobClient = GetAppendBlobClient(fileId);
             var properties = await blobClient.GetPropertiesAsync(cancellationToken: cancellationToken);
             return properties.Value.Metadata.ToDictionary(k => k.Key, v => v.Value);
+        }
+
+        public void Dispose()
+        {
+            _containerSemaphore?.Dispose();
         }
     }
 }

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
@@ -32,12 +32,12 @@ namespace Xtensible.TusDotNet.Azure
         private const string UploadOffsetKey = "UploadOffset";
         private const string MD5ChecksumKey = "MD5Checksum";
 
-        private static bool _containerExists;
-        private static readonly SemaphoreSlim ContainerSemaphore = new SemaphoreSlim(1);
         private static readonly IEnumerable<string> SupportedChecksumAlgorithms = new ReadOnlyCollection<string>(new[] { "md5" });
         private readonly string _connectionString;
         private readonly string _containerName;
         private readonly string _blobPath;
+        private readonly SemaphoreSlim _containerSemaphore = new(1);
+        private bool _containerExists;
         private readonly bool _isContainerPublic;
         private readonly int _maxDegreeOfDeleteParallelism;
         private readonly MetadataParsingStrategy _metadataParsingStrategy;
@@ -243,7 +243,7 @@ namespace Xtensible.TusDotNet.Azure
             await blobClient.DeleteAsync(cancellationToken: cancellationToken);
         }
 
-        private async static Task EnsureContainerExistsAsync(AzureBlobTusStoreAuthenticationMode authenticationMode, string connectionString, string containerName, bool isContainerPublic,
+        private async Task EnsureContainerExistsAsync(AzureBlobTusStoreAuthenticationMode authenticationMode, string connectionString, string containerName, bool isContainerPublic,
             CancellationToken cancellationToken)
         {
             if (_containerExists)
@@ -251,17 +251,25 @@ namespace Xtensible.TusDotNet.Azure
                 return;
             }
 
-            await ContainerSemaphore.WaitAsync(60000, cancellationToken).ConfigureAwait(false);
+            await _containerSemaphore.WaitAsync(60000, cancellationToken).ConfigureAwait(false);
 
-            if (_containerExists)
+            try
             {
-                return;
+                if (_containerExists)
+                {
+                    return;
+                }
+
+                var containerClient = AzureBlobClientFactory.CreateBlobContainerClient(authenticationMode, connectionString, containerName);
+                await containerClient.CreateIfNotExistsAsync(isContainerPublic ? PublicAccessType.BlobContainer : PublicAccessType.None,
+                    cancellationToken: cancellationToken);
+                _containerExists = true;
             }
-            var containerClient = AzureBlobClientFactory.CreateBlobContainerClient(authenticationMode, connectionString, containerName);
-            await containerClient.CreateIfNotExistsAsync(isContainerPublic ? PublicAccessType.BlobContainer : PublicAccessType.None,
-                cancellationToken: cancellationToken);
-            _containerExists = true;
-            ContainerSemaphore.Release(1);
+            finally
+            {
+                _containerSemaphore.Release(1);
+            }
+
         }
 
         public Task<IEnumerable<string>> GetSupportedAlgorithmsAsync(CancellationToken cancellationToken)

--- a/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
+++ b/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
@@ -36,7 +36,7 @@
     <RepositoryUrl>https://github.com/giometrix/Xtensible.TusDotNet.Azure</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>tus;tusdotnet;azure;blob;azure-blob-storage;upload</PackageTags>
-    <PackageReleaseNotes>Fix md5 hash in high throughput situations</PackageReleaseNotes>
+    <PackageReleaseNotes>Allow for multiple containers</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageIcon>xtensible-x.png</PackageIcon>

--- a/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
+++ b/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
@@ -36,7 +36,7 @@
     <RepositoryUrl>https://github.com/giometrix/Xtensible.TusDotNet.Azure</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>tus;tusdotnet;azure;blob;azure-blob-storage;upload</PackageTags>
-    <PackageReleaseNotes>Adds support for Azure Managed Identity</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix md5 hash in high throughput situations</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageIcon>xtensible-x.png</PackageIcon>

--- a/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
+++ b/src/Xtensible.TusDotNet.Azure/Xtensible.TusDotNet.Azure.csproj
@@ -42,7 +42,7 @@
     <PackageIcon>xtensible-x.png</PackageIcon>
     <AssemblyVersion>1.4.0.0</AssemblyVersion>
     <FileVersion>1.4.0.0</FileVersion>
-    <Version>2.1.1</Version>
+    <Version>2.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">

--- a/test/Xtensible.TusDotNet.Azure.Tests/BlobStorageTests.cs
+++ b/test/Xtensible.TusDotNet.Azure.Tests/BlobStorageTests.cs
@@ -105,7 +105,7 @@ namespace Xtensible.TusDotNet.Azure.Tests
             var id = await _azureBlobTusStore.CreateFileAsync(fileInfo.Length, GetMetadata(("test", "1"), ("a", "b"), ("test-id", nameof(delete_file))), CancellationToken.None);
             await _azureBlobTusStore.DeleteFileAsync(id, CancellationToken.None);
 
-            var azureBlobTusStore2 = new AzureBlobTusStore(_connectionString, ContainerName + "2");
+            using var azureBlobTusStore2 = new AzureBlobTusStore(_connectionString, ContainerName + "2");
             id = await azureBlobTusStore2.CreateFileAsync(fileInfo.Length, GetMetadata(("test", "1"), ("a", "b"), ("test-id", nameof(delete_file))), CancellationToken.None);
             await azureBlobTusStore2.DeleteFileAsync(id, CancellationToken.None);
 

--- a/test/Xtensible.TusDotNet.Azure.Tests/BlobStorageTests.cs
+++ b/test/Xtensible.TusDotNet.Azure.Tests/BlobStorageTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Configuration;
 using tusdotnet.Models;
@@ -95,7 +96,22 @@ namespace Xtensible.TusDotNet.Azure.Tests
             await _azureBlobTusStore.DeleteFileAsync(id, CancellationToken.None);
 
         }
-        
+
+        [Fact]
+        public async Task create_file_multiple_containers_should_not_fail()
+        {
+            var fileInfo = new FileInfo(SmallFileName);
+
+            var id = await _azureBlobTusStore.CreateFileAsync(fileInfo.Length, GetMetadata(("test", "1"), ("a", "b"), ("test-id", nameof(delete_file))), CancellationToken.None);
+            await _azureBlobTusStore.DeleteFileAsync(id, CancellationToken.None);
+
+            var azureBlobTusStore2 = new AzureBlobTusStore(_connectionString, ContainerName + "2");
+            id = await azureBlobTusStore2.CreateFileAsync(fileInfo.Length, GetMetadata(("test", "1"), ("a", "b"), ("test-id", nameof(delete_file))), CancellationToken.None);
+            await azureBlobTusStore2.DeleteFileAsync(id, CancellationToken.None);
+
+            var client = new BlobContainerClient(_connectionString, ContainerName + 2);
+            await client.DeleteAsync();
+        }
 
         [Fact]
         public async Task create_file_with_path()


### PR DESCRIPTION
Similar to PR https://github.com/giometrix/Xtensible.TusDotNet.Azure/pull/10 by @Tyomnat, where we now allow multiple containers to be used.

The PR above accomplished this goal, but removed a cached existance check.

I believe in most cases, the lifetime of `AzureBlobTusStore` is as a singleton, and that if someone needs more than one, they'll use multiple singletons. As such, I think they will appreciate the cached check. For those that don't, the performance will be the same as the original PR.

This PR also makes the `AzureBlobTusStore` disposable. It probably should always have been disposable, but now that we're expecting some shorter lived lifespans, it's even more imoortant.