### PR TITLE
Prevent possible blob data corruption after append cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,25 @@ Unfortunately, it does not yet support tags (see [issue](https://github.com/Azur
 To work around this, I have split out the expiration stuff into a separate interface `ITusExpirationDetailsStore` and implemented `NullExpirationDetailsStore`.
 
 This allows you to use an external database (for just dev, or both prod and dev), or you can use `NullExpirationDetailsStore` in dev to forego using the expiration feature when using Azurite.
+
+### Version notes
+
+#### Why is the `UploadOffset` property on my upload blob missing or not updating anymore?
+
+In version 3.0.0 the `UploadOffset` property was deprecated in favor of the actual `Content-Length` HTTP property of the blob.
+
+This was done to fix possible upload blob data corruption when resuming uploads after a broken/cancelled connection and has the following (unproblematic) side effects:
+
+* Existing upload blobs created with version < 3.0.0 contain an `UploadOffset` property which is not updated anymore after updating to version ≥ 3.0.0.
+* New upload blobs created with version ≥ 3.0.0 do not contain an `UploadOffset` property at all.
+
+#### Can I prevent blob data corruption with versions < 3.x?
+
+Yes, by choosing a TUS chunk size ≤ 4 MiB (4 194 304 bytes). Please note that such small chunk sizes are not recommended because they reduce upload performance.
+
+#### Can I downgrade from version 3.x to 2.x?
+
+**Please don't, there is no reason why you should need or want to.**
+Uploads will either fail or become corrupt if you do it anyway.
+
+(It is possible, at your own risk, by making sure you set the `UploadOffset` metadata property on each upload blob to the exact same value as the `Content-Length` property of the blob, after stopping existing uploads and before deploying version 2.x.)

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
@@ -294,19 +294,23 @@ namespace Xtensible.TusDotNet.Azure
             return AzureBlobClientFactory.CreateAppendBlobClient(_authenticationMode, _connectionString, _containerName, Path.Combine(_blobPath, fileId));
         }
 
-        private async Task<string> GetBlobMetadataAsync(string fileId, string key, CancellationToken cancellationToken)
+        private async Task<BlobProperties> GetBlobPropertiesAsync(string fileId, CancellationToken cancellationToken)
         {
             var blobClient = GetAppendBlobClient(fileId);
-            var properties = await blobClient.GetPropertiesAsync(cancellationToken: cancellationToken);
-            properties.Value.Metadata.TryGetValue(key, out var value);
+            return (await blobClient.GetPropertiesAsync(cancellationToken: cancellationToken)).Value;
+        }
+
+        private async Task<string> GetBlobMetadataAsync(string fileId, string key, CancellationToken cancellationToken)
+        {
+            var properties = await GetBlobPropertiesAsync(fileId, cancellationToken);
+            properties.Metadata.TryGetValue(key, out var value);
             return value;
         }
 
         private async Task<Dictionary<string, string>> GetBlobMetadataAsync(string fileId, CancellationToken cancellationToken)
         {
-            var blobClient = GetAppendBlobClient(fileId);
-            var properties = await blobClient.GetPropertiesAsync(cancellationToken: cancellationToken);
-            return properties.Value.Metadata.ToDictionary(k => k.Key, v => v.Value);
+            var properties = await GetBlobPropertiesAsync(fileId, cancellationToken);
+            return properties.Metadata.ToDictionary(k => k.Key, v => v.Value);
         }
 
         public void Dispose()

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
@@ -30,12 +30,6 @@ namespace Xtensible.TusDotNet.Azure
         private const string RawMetadataKey = "RawMetadata";
         private const string MD5ChecksumKey = "MD5Checksum";
 
-        // Keep this metadata property for now and set it to a const info string so that users are not confused by outdated values?
-        // Alternative: keep the const key name and remove it when reading metadata properties.
-        [Obsolete]
-        private const string UploadOffsetKey = "UploadOffset";
-        private const string UploadOffsetObsoleteValue = "not used anymore, see Content-Length property";
-
         private static readonly IEnumerable<string> SupportedChecksumAlgorithms = new ReadOnlyCollection<string>(new[] { "md5" });
         private readonly string _connectionString;
         private readonly string _containerName;
@@ -81,8 +75,7 @@ namespace Xtensible.TusDotNet.Azure
             var metadataDictionary = new Dictionary<string, string>
             {
                 [UploadLengthKey] = uploadLength.ToString(),
-                [RawMetadataKey] = metadata ?? string.Empty,
-                [UploadOffsetKey] = UploadOffsetObsoleteValue
+                [RawMetadataKey] = metadata ?? string.Empty
             };
             _updateAzureMeta(metadataDictionary);
 
@@ -210,7 +203,6 @@ namespace Xtensible.TusDotNet.Azure
                     }
                 }
 
-                metadata[UploadOffsetKey] = UploadOffsetObsoleteValue;
                 metadata[MD5ChecksumKey] = Convert.ToBase64String(md5Hash);
                 await appendBlobClient.SetMetadataAsync(metadata, cancellationToken: cancellationToken);
             }

--- a/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
+++ b/src/Xtensible.TusDotNet.Azure/AzureBlobTusStore.cs
@@ -285,8 +285,8 @@ namespace Xtensible.TusDotNet.Azure
 
         public async Task<bool> VerifyChecksumAsync(string fileId, string algorithm, byte[] checksum, CancellationToken cancellationToken)
         {
-            var metadata = await GetBlobMetadataAsync(fileId, cancellationToken);
-            if (metadata.TryGetValue(MD5ChecksumKey, out var md5))
+            var md5 = await GetBlobMetadataAsync(fileId, MD5ChecksumKey, cancellationToken);
+            if (md5 != null)
             {
                 if (md5 == Convert.ToBase64String(checksum))
                 {
@@ -312,12 +312,6 @@ namespace Xtensible.TusDotNet.Azure
             var properties = await GetBlobPropertiesAsync(fileId, cancellationToken);
             properties.Metadata.TryGetValue(key, out var value);
             return value;
-        }
-
-        private async Task<Dictionary<string, string>> GetBlobMetadataAsync(string fileId, CancellationToken cancellationToken)
-        {
-            var properties = await GetBlobPropertiesAsync(fileId, cancellationToken);
-            return properties.Metadata.ToDictionary(k => k.Key, v => v.Value);
         }
 
         public void Dispose()

--- a/test/Xtensible.TusDotNet.Azure.Tests/CancellationTriggeringReadingFileStream.cs
+++ b/test/Xtensible.TusDotNet.Azure.Tests/CancellationTriggeringReadingFileStream.cs
@@ -1,0 +1,53 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xtensible.TusDotNet.Azure.Tests
+{
+    /// <summary>
+    /// A FileStream which triggers a <see cref="CancellationTokenSource"/> after an exact specified amount of bytes is read.
+    /// </summary>
+    internal class CancellationTriggeringReadingFileStream : FileStream
+    {
+        private readonly CancellationTokenSource _cancellationTokenSource;
+        private readonly long _cancelAfterReadingBytes;
+
+        // We have to track the position ourselves, the Position property throws when CanSeek == false.
+        private long _position = 0;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CancellationTriggeringReadingFileStream"/> class.
+        /// </summary>
+        /// <param name="path"><inheritdoc cref="FileStream.FileStream(string, FileMode)" path="/param[@name='path']"/></param>
+        /// <param name="cancellationTokenSource">The <see cref="CancellationTokenSource"/> which should be triggered.</param>
+        /// <param name="cancelAfterReadingBytes">The amount of bytes after which the <paramref name="cancellationTokenSource"/> is triggered.</param>
+        public CancellationTriggeringReadingFileStream(string path, CancellationTokenSource cancellationTokenSource, long cancelAfterReadingBytes)
+            : base(path, FileMode.Open, FileAccess.Read, FileShare.Read)
+        {
+            _cancellationTokenSource = cancellationTokenSource;
+            _cancelAfterReadingBytes = cancelAfterReadingBytes;
+        }
+
+        // CanSeek should return false to make sure this class works correctly.
+        public override bool CanSeek => false;
+
+        // This is the only "Stream.Read..." method which is used by the AzureBlobTusStorage.AppendDataAsync(...) method.
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (_position >= _cancelAfterReadingBytes)
+            {
+                await _cancellationTokenSource.CancelAsync();
+            }
+            else if (_position + count > _cancelAfterReadingBytes)
+            {
+                count = (int)(_cancelAfterReadingBytes - _position);
+            }
+
+            var read = await base.ReadAsync(buffer, offset, count, cancellationToken);
+
+            _position += read;
+
+            return read;
+        }
+    }
+}


### PR DESCRIPTION
A test demonstrating the problem is contained in the first commit. If it is run without the fixes in the following commits, the bug can be reproduced and debugged step-by-step.

The following commits replace the `UploadOffset` metadata element, which could get out-of-sync with the actual blob length, with direct use of the blob Content-Length property.

As for the `UploadOffset` metadata element, I had four possible choices regarding in-progress uploads that were created before this pull request and other developers' expectations of its existence (ordered from my least to most favorite choice):
1. keep setting it during create/append actions, but never actually use it in code => it could get out of sync, like before, but that would be temporary and it would do no harm anymore
2. completely remove it from code => existing in-progress uploads would be stuck with an unchanging value in the metadata element, which could cause confusion
3. keep its name/key in code (for now) and set it to a hint with the next append action => would tell developers where to find the value
4. keep its name/key in code (for now) and remove it automatically with the next append action => could developers be asking themselves, where it went?

In the end, I went with choice 3. If you prefer 2 (cleanest code) or 4 (cleanest blobs), I could switch to one of them. Choice 1 is out of the question, I think.

Fixes #12 